### PR TITLE
Upgrade to 1.0 version of embedded-hal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bmi088"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Todd Stellanova <tstellanova@users.noreply.github.com>"]
 edition = "2018"
 description = "BMI088 6DOF IMU driver for embedded hal"
@@ -21,7 +21,7 @@ keywords = [
 readme = "README.md"
 
 [dependencies]
-embedded-hal = { version = "0.2.3", features = ["unproven"] }
+embedded-hal = { version = "1.0.0" }
 
 [dev-dependencies]
 embedded-hal-mock = "0.7.1"

--- a/src/interface/i2c.rs
+++ b/src/interface/i2c.rs
@@ -12,9 +12,7 @@ pub struct I2cInterface<I2C> {
 
 impl<I2C, CommE> I2cInterface<I2C>
 where
-    I2C: hal::blocking::i2c::Read<Error = CommE>
-        + hal::blocking::i2c::Write<Error = CommE>
-        + hal::blocking::i2c::WriteRead<Error = CommE>,
+    I2C: hal::i2c::I2c<Error = CommE>
 {
     pub fn new(i2c: I2C, address: u8) -> Self {
         Self {
@@ -26,9 +24,7 @@ where
 
 impl<I2C, CommE> SensorInterface for I2cInterface<I2C>
 where
-    I2C: hal::blocking::i2c::Read<Error = CommE>
-        + hal::blocking::i2c::Write<Error = CommE>
-        + hal::blocking::i2c::WriteRead<Error = CommE>,
+    I2C: hal::i2c::I2c<Error = CommE>
 {
     type InterfaceError = Error<CommE, ()>;
 


### PR DESCRIPTION
This upgrades the crate to comply with the 1.0 version of embedded-hal. I tested it and everything works fine. Some things were renamed and the CS Pin is now handled by the hal implementation, so we don't need to worry about that.

It would be cool if we could upgrade the crate.